### PR TITLE
"database" and "password" were not local variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var url = require('url');
 
 module.exports.createClient = module.exports.connect = function(redis_url) {
+  var password, database;
   var parsed_url  = url.parse(redis_url || process.env.REDIS_URL || 'redis://localhost:6379');
   var parsed_auth = (parsed_url.auth || '').split(':');
 


### PR DESCRIPTION
following script does output my password.

```
var redis = require('redis-url').createClient(process.env.REDISTOGO_URL);
console.log(password);
redis.quit();
```
