### PR TITLE
Add options argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var url = require('url');
 
-module.exports.createClient = module.exports.connect = function(redis_url) {
+module.exports.createClient = module.exports.connect = function(redis_url, options) {
   var password, database;
   var parsed_url  = url.parse(redis_url || process.env.REDIS_URL || 'redis://localhost:6379');
   var parsed_auth = (parsed_url.auth || '').split(':');
 
-  var redis = require('redis').createClient(parsed_url.port, parsed_url.hostname);
+  var redis = require('redis').createClient(parsed_url.port, parsed_url.hostname, options);
 
   if (password = parsed_auth[1]) {
     redis.auth(password, function(err) {


### PR DESCRIPTION
This commit adds the ability to pass options through to the call to redis.createClient.
