### PR TITLE
username should not be used to select database

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,27 +2,27 @@ var url = require('url');
 var querystring = require('querystring');
 
 module.exports.createClient = module.exports.connect = function(redis_url) {
-  var password, database;
   var parsed_url  = url.parse(redis_url || process.env.REDIS_URL || 'redis://localhost:6379');
   var parsed_auth = (parsed_url.auth || '').split(':');
   var options = querystring.parse(parsed_url.query);
+  var password = parsed_auth[1];
+  var path = (parsed_url.pathname || '/').slice(1);
+  var database = path.length ? path : '0';
 
   var redis = require('redis').createClient(parsed_url.port, parsed_url.hostname, options);
 
-  if (password = parsed_auth[1]) {
+  if (password) {
     redis.auth(password, function(err) {
       if (err) throw err;
     });
   }
 
-  if (database = parsed_auth[0]) {
+  redis.select(database);
+  redis.on('connect', function() {
+    redis.send_anyways = true
     redis.select(database);
-    redis.on('connect', function() {
-      redis.send_anyways = true
-      redis.select(database);
-      redis.send_anyways = false;
-    });
-  }
+    redis.send_anyways = false;
+  });
 
   return(redis);
 }


### PR DESCRIPTION
redis-url won't work with cloud providers like Heroku's RedisCloud because it treats the (ignorable) username as the database name. Thus:

`REDISCLOUD_URL='redis://rediscloud:sadfsfsdfsdf@pub-redis-1234.us-east-1-4.3.ec2.garantiadata.com:1234'`

... tries to connect to database 'rediscloud' instead of database '0' as would be expected. This patch ignores the username and defaults to db 0 when a database hasn't been supplied like:

`REDISCLOUD_URL='redis://rediscloud:sadfsfsdfsdf@pub-redis-1234.us-east-1-4.3.ec2.garantiadata.com:1234/1'`

A full working example can be seen here:
- https://github.com/heroku-examples/node-articles-nlp/blob/master/script/reset#L11
- https://github.com/heroku-examples/node-articles-nlp/blob/master/package.json#L36
