### PR TITLE
allow users to omit protocol in .parse()

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,20 @@ module.exports.createClient = module.exports.connect = function(redis_url) {
 }
 
 var parse = module.exports.parse = function(url) {
-  var parsed = URL.parse(url, true)
+  var parsed = URL.parse(url, true, true)
+
+  if (!parsed.slashes && url[0] !== '/') {
+    // We require slashes after protocol name, e.g. "redis://whatever:1234"
+    // is correct, but "redis:whatever:1234" is not.
+    //
+    // Therefore, if parser see no slashes, we can assume that protocol is
+    // omitted (e.g. "whatever:1234")
+    //
+    // Just add slashes in this case and try again.
+    url = '//' + url
+    parsed = URL.parse(url, true, true)
+  }
+
   parsed.password = (parsed.auth || '').split(':')[1];
   parsed.path = (parsed.pathname || '/').slice(1);
   parsed.database = parsed.path.length ? parsed.path : '0';

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var test = require("tape")
 
 test("redis-url", function (t) {
-  t.plan(16)
+  t.plan(30)
 
   // Parse a simple URL
   var parts = require('..').parse('redis://localhost:6379')
@@ -16,6 +16,26 @@ test("redis-url", function (t) {
   // Parse a more complex URL
   parts = require('..').parse('redis://:secrets@example.com:1234/9?foo=bar&baz=qux')
   t.equal(parts.password, 'secrets')
+  t.equal(parts.host, 'example.com:1234')
+  t.equal(parts.hostname, 'example.com')
+  t.equal(parts.port, '1234')
+  t.equal(parts.path, '9')
+  t.equal(parts.database, '9')
+  t.deepEqual(parts.query, {foo: 'bar', baz: 'qux'})
+
+  // Simple url, no protocol submitted
+  parts = require('..').parse('localhost:6379')
+  t.equal(parts.password, undefined)
+  t.equal(parts.host, 'localhost:6379')
+  t.equal(parts.hostname, 'localhost')
+  t.equal(parts.port, '6379')
+  t.equal(parts.path, '')
+  t.equal(parts.database, '0')
+  t.deepEqual(parts.query, {})
+
+  // More complex one
+  parts = require('..').parse(':pass@example.com:1234/9?foo=bar&baz=qux')
+  t.equal(parts.password, 'pass')
   t.equal(parts.host, 'example.com:1234')
   t.equal(parts.hostname, 'example.com')
   t.equal(parts.port, '1234')


### PR DESCRIPTION
Patch allows to omit protocol name, i.e. `//localhost:6379/` (usual RFC notation when the protocol is known) and `localhost:6379` (that's usual lazy user notation).

Note that if protocol is present, we require it to be followed by two slashes. E.g. `redis://localhost:6739` is valid, but `redis:localhost:6739` is not. Node.js parser allows either, but this particular algorithm does not, otherwise omitting protocol might be ambiguous (`redis:user@localhost:1234` vs `user:pass@localhost:1234`). I think it's good enough for practical purposes though.

Fixes https://github.com/ddollar/redis-url/issues/12