### PR TITLE
add parsing nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var URL = require('url');
+var qs = require('qs');
 
 module.exports.createClient = module.exports.connect = function(redis_url, redis_module) {
   var parsed = parse(redis_url || process.env.REDIS_URL || 'redis://localhost:6379')
@@ -23,7 +24,7 @@ module.exports.createClient = module.exports.connect = function(redis_url, redis
 }
 
 var parse = module.exports.parse = function(url) {
-  var parsed = URL.parse(url, true, true)
+  var parsed = URL.parse(url, false, true)
 
   if (!parsed.slashes && url[0] !== '/') {
     // We require slashes after protocol name, e.g. "redis://whatever:1234"
@@ -34,8 +35,10 @@ var parse = module.exports.parse = function(url) {
     //
     // Just add slashes in this case and try again.
     url = '//' + url
-    parsed = URL.parse(url, true, true)
+    parsed = URL.parse(url, false, true)
   }
+
+  parsed.query = qs.parse(parsed.query, { allowDots: true });
 
   parsed.password = (parsed.auth || '').split(':')[1];
   parsed.path = (parsed.pathname || '/').slice(1);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "./index.js",
   "dependencies": {
+    "qs": ">= 0.0.1",
     "redis": ">= 0.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var test = require("tape")
 
 test("redis-url", function (t) {
-  t.plan(32)
+  t.plan(46)
 
   // Parse a simple URL
   var parts = require('..').parse('redis://localhost:6379')
@@ -22,6 +22,26 @@ test("redis-url", function (t) {
   t.equal(parts.path, '9')
   t.equal(parts.database, '9')
   t.deepEqual(parts.query, {foo: 'bar', baz: 'qux'})
+
+  // Parse a more complex URL (nested objects)
+  parts = require('..').parse('redis://:secrets@example.com:1234/9?foo[abc]=bar&baz=qux')
+  t.equal(parts.password, 'secrets')
+  t.equal(parts.host, 'example.com:1234')
+  t.equal(parts.hostname, 'example.com')
+  t.equal(parts.port, '1234')
+  t.equal(parts.path, '9')
+  t.equal(parts.database, '9')
+  t.deepEqual(parts.query, {foo: {abc: 'bar'}, baz: 'qux'})
+
+  // Parse a more complex URL (nested objects - dotted natation)
+  parts = require('..').parse('redis://:secrets@example.com:1234/9?foo.abc=bar&baz=qux')
+  t.equal(parts.password, 'secrets')
+  t.equal(parts.host, 'example.com:1234')
+  t.equal(parts.hostname, 'example.com')
+  t.equal(parts.port, '1234')
+  t.equal(parts.path, '9')
+  t.equal(parts.database, '9')
+  t.deepEqual(parts.query, {foo: {abc: 'bar'}, baz: 'qux'})
 
   // Simple url, no protocol submitted
   parts = require('..').parse('localhost:6379')


### PR DESCRIPTION
Regular url.parse doesn't work with nested objects in query-string:
```
foo[aaa]=bar&bbb.ccc=ddd
```
it parses it to
```
query = {
   "foo[aaa]: "bar",
   "bbb.ccc": "ddd"
}
```
This is not good because because the two redis parameters may be objects: `rename_commands`, `tsl`

F.e. I have the options:
```
options = {
  tsl: {
    servername: 'blablah.com'
  }
}
```
For now I cannot represent this as an redis url string.

The PR fixes this. This
```
foo[aaa]=bar&bbb.ccc=ddd
```
would be parsed to
```
query = {
   "foo": {"aaa": "bar"},
   "bbb": {"ccc": "ddd"}
}
```

I use the https://www.npmjs.com/package/qs great module for this. It's fully supported and has more that 30m of downloads per month.

I suggest to create a new major version if you think the PR is helpful.

PS. I also add tests for the feature.
